### PR TITLE
Make server time verification offset larger

### DIFF
--- a/server/api/leaderboard.js
+++ b/server/api/leaderboard.js
@@ -100,6 +100,7 @@ function isWithinReasonableTime(session, time) {
     return false;
   }
   const duration = (session.stop - session.start) / 1000;
-  // time should be +/- 0.3 sec from duration (given network delays etc, we can tighten this later if needed)
-  return time >= duration - 0.3 && time <= duration + 0.3;
+  const offsetToAccountForNetworkDelays = 0.5; // seconds
+
+  return time >= duration - offsetToAccountForNetworkDelays && time <= duration + offsetToAccountForNetworkDelays;
 }


### PR DESCRIPTION
My initial test had more than 0.3 sec time diff between server and recorded client side time, so bumping margin to 0.5 sec. We can make this configurable in env var if you prefer.